### PR TITLE
検索機能を追加する

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "astro": "^5.1.2",
         "budoux": "^0.6.3",
         "daisyui": "^4.12.14",
+        "pagefind": "^1.3.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "remark-link-card": "^1.3.1",
@@ -1688,6 +1689,71 @@
       "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
       "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
       "license": "MIT"
+    },
+    "node_modules/@pagefind/darwin-arm64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-arm64/-/darwin-arm64-1.3.0.tgz",
+      "integrity": "sha512-365BEGl6ChOsauRjyVpBjXybflXAOvoMROw3TucAROHIcdBvXk9/2AmEvGFU0r75+vdQI4LJdJdpH4Y6Yqaj4A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/darwin-x64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-x64/-/darwin-x64-1.3.0.tgz",
+      "integrity": "sha512-zlGHA23uuXmS8z3XxEGmbHpWDxXfPZ47QS06tGUq0HDcZjXjXHeLG+cboOy828QIV5FXsm9MjfkP5e4ZNbOkow==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/linux-arm64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-arm64/-/linux-arm64-1.3.0.tgz",
+      "integrity": "sha512-8lsxNAiBRUk72JvetSBXs4WRpYrQrVJXjlRRnOL6UCdBN9Nlsz0t7hWstRk36+JqHpGWOKYiuHLzGYqYAqoOnQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/linux-x64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-x64/-/linux-x64-1.3.0.tgz",
+      "integrity": "sha512-hAvqdPJv7A20Ucb6FQGE6jhjqy+vZ6pf+s2tFMNtMBG+fzcdc91uTw7aP/1Vo5plD0dAOHwdxfkyw0ugal4kcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/windows-x64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-x64/-/windows-x64-1.3.0.tgz",
+      "integrity": "sha512-BR1bIRWOMqkf8IoU576YDhij1Wd/Zf2kX/kCI0b2qzCKC8wcc2GQJaaRMCpzvCCrmliO4vtJ6RITp/AnoYUUmQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -8535,6 +8601,22 @@
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
       "integrity": "sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==",
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/pagefind": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pagefind/-/pagefind-1.3.0.tgz",
+      "integrity": "sha512-8KPLGT5g9s+olKMRTU9LFekLizkVIu9tes90O1/aigJ0T5LmyPqTzGJrETnSw3meSYg58YH7JTzhTTW/3z6VAw==",
+      "license": "MIT",
+      "bin": {
+        "pagefind": "lib/runner/bin.cjs"
+      },
+      "optionalDependencies": {
+        "@pagefind/darwin-arm64": "1.3.0",
+        "@pagefind/darwin-x64": "1.3.0",
+        "@pagefind/linux-arm64": "1.3.0",
+        "@pagefind/linux-x64": "1.3.0",
+        "@pagefind/windows-x64": "1.3.0"
+      }
     },
     "node_modules/pako": {
       "version": "0.2.9",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
-    "build": "astro build",
+    "build": "astro build && pagefind --site dist",
     "preview": "astro preview",
     "astro": "astro"
   },
@@ -21,6 +21,7 @@
     "astro": "^5.1.2",
     "budoux": "^0.6.3",
     "daisyui": "^4.12.14",
+    "pagefind": "^1.3.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "remark-link-card": "^1.3.1",

--- a/src/components/Search.astro
+++ b/src/components/Search.astro
@@ -13,12 +13,13 @@
 <dialog id="searchModal" class="modal">
   <div class="modal-box">
     <form method="dialog">
-      <button class="btn btn-ghost btn-xs absolute right-3 top-3">
+      <button class="btn btn-circle btn-ghost btn-xs absolute right-2 top-2">
         <svg
           xmlns="http://www.w3.org/2000/svg"
-          class="h-4 w-4"
+          class="fill-current h-4 w-4"
           fill="none"
           viewBox="0 0 24 24"
+          stroke="currentColor"
         >
           <path
             stroke-linecap="round"
@@ -28,42 +29,53 @@
         </svg>
       </button>
     </form>
-    <div id="search-box" class="mt-4"></div>
+    <div id="search-box" class="mt-4 mb-2"></div>
   </div>
   <form method="dialog" class="modal-backdrop">
     <button>close</button>
   </form>
 </dialog>
 
-<link rel="stylesheet" href="/pagefind/pagefind-ui.css" />
 <script is:inline src="/pagefind/pagefind-ui.js"></script>
 <script is:inline>
   document.getElementById("search").addEventListener("click", () => {
+    console.log("🍎🍎🍎click");
     document.getElementById("searchModal").showModal();
+  });
+  document.getElementById("searchModal").addEventListener("open", () => {
+    console.log("🍎🍎🍎shown modal");
+    document
+      .querySelector(".pagefind-ui__form.pagefind-ui__search-input")
+      .focus();
   });
   document.addEventListener("DOMContentLoaded", () => {
     new PagefindUI({ element: "#search-box" });
   });
 </script>
 
-<style>
-  @media (prefers-color-scheme: dark) {
-    .modal-box {
-      --pagefind-ui-primary: #1f2937; /* night: --pf-primary */
-      --pagefind-ui-text: #374151; /* night: --pf-text */
-      --pagefind-ui-background: #ffffff; /* winter: --pf-background */
-      --pagefind-ui-border: #374151; /* night: --pf-border */
-      --pagefind-ui-tag: #4b5563; /* night: --pf-tag */
-    }
+<link rel="stylesheet" href="/pagefind/pagefind-ui.css" />
+<!--
+ スタイルを当てるワークアラウンド pagefindのcssをmediaqueriesでは上書きできないため
+ ref https://github.com/CloudCannon/pagefind/issues/614#issuecomment-2111199944
+
+ !importantをつけることでrootの設定を上書きできるようにしている
+-->
+<style is:global>
+  [data-theme="night"] {
+    --pagefind-ui-primary: #9ca3af !important;
+    --pagefind-ui-text: #9ca3af !important;
+    --pagefind-ui-background: #0f172a !important;
+    --pagefind-ui-border: #4b5563 !important;
+    --pagefind-ui-tag: #4b5563 !important;
+    --pagefind-ui-font: Noto Sans JP, Proxima Nova, system-ui, sans-serif !important;
   }
 
-  @media (prefers-color-scheme: light) {
-    .modal-box {
-      --pagefind-ui-primary: #1f2937; /* night: --pf-primary */
-      --pagefind-ui-text: #374151; /* night: --pf-text */
-      --pagefind-ui-background: #ffffff; /* winter: --pf-background */
-      --pagefind-ui-border: #d1d5db; /* winter: --pf-border */
-      --pagefind-ui-tag: #e5e7eb; /* winter: --pf-tag */
-    }
+  [data-theme="light"] {
+    --pagefind-ui-primary: #1f2937 !important;
+    --pagefind-ui-text: #374151 !important;
+    --pagefind-ui-background: #ffffff !important;
+    --pagefind-ui-border: #d1d5db !important;
+    --pagefind-ui-tag: #e5e7eb !important;
+    --pagefind-ui-font: Noto Sans JP, Proxima Nova, system-ui, sans-serif !important;
   }
 </style>

--- a/src/components/Search.astro
+++ b/src/components/Search.astro
@@ -39,14 +39,7 @@
 <script is:inline src="/pagefind/pagefind-ui.js"></script>
 <script is:inline>
   document.getElementById("search").addEventListener("click", () => {
-    console.log("🍎🍎🍎click");
     document.getElementById("searchModal").showModal();
-  });
-  document.getElementById("searchModal").addEventListener("open", () => {
-    console.log("🍎🍎🍎shown modal");
-    document
-      .querySelector(".pagefind-ui__form.pagefind-ui__search-input")
-      .focus();
   });
   document.addEventListener("DOMContentLoaded", () => {
     new PagefindUI({ element: "#search-box" });

--- a/src/components/Search.astro
+++ b/src/components/Search.astro
@@ -49,9 +49,9 @@
 <style>
   @media (prefers-color-scheme: dark) {
     .modal-box {
-      --pagefind-ui-primary: #a6adba; /* winter: --pf-primary */
-      --pagefind-ui-text: #d1d5db; /* winter: --pf-text */
-      --pagefind-ui-background: #1f2937; /* night: --pf-background */
+      --pagefind-ui-primary: #1f2937; /* night: --pf-primary */
+      --pagefind-ui-text: #374151; /* night: --pf-text */
+      --pagefind-ui-background: #ffffff; /* winter: --pf-background */
       --pagefind-ui-border: #374151; /* night: --pf-border */
       --pagefind-ui-tag: #4b5563; /* night: --pf-tag */
     }

--- a/src/components/Search.astro
+++ b/src/components/Search.astro
@@ -45,3 +45,25 @@
     new PagefindUI({ element: "#search-box" });
   });
 </script>
+
+<style>
+  @media (prefers-color-scheme: dark) {
+    .modal-box {
+      --pagefind-ui-primary: #a6adba; /* winter: --pf-primary */
+      --pagefind-ui-text: #d1d5db; /* winter: --pf-text */
+      --pagefind-ui-background: #1f2937; /* night: --pf-background */
+      --pagefind-ui-border: #374151; /* night: --pf-border */
+      --pagefind-ui-tag: #4b5563; /* night: --pf-tag */
+    }
+  }
+
+  @media (prefers-color-scheme: light) {
+    .modal-box {
+      --pagefind-ui-primary: #1f2937; /* night: --pf-primary */
+      --pagefind-ui-text: #374151; /* night: --pf-text */
+      --pagefind-ui-background: #ffffff; /* winter: --pf-background */
+      --pagefind-ui-border: #d1d5db; /* winter: --pf-border */
+      --pagefind-ui-tag: #e5e7eb; /* winter: --pf-tag */
+    }
+  }
+</style>

--- a/src/components/Search.astro
+++ b/src/components/Search.astro
@@ -1,0 +1,47 @@
+<label id="search" class="btn btn-square btn-ghost swap">
+  <svg
+    class="fill-current w-5 h-5"
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 20"
+  >
+    <path
+      d="M 10 2 C 5.5965257 2 2 5.5965291 2 10 C 2 14.403471 5.5965257 18 10 18 C 11.752132 18 13.370523 17.422074 14.691406 16.458984 L 19.845703 21.613281 A 1.250125 1.250125 0 1 0 21.613281 19.845703 L 16.458984 14.691406 C 17.422074 13.370523 18 11.75213 18 10 C 18 5.5965291 14.403474 2 10 2 z M 10 4.5 C 13.052375 4.5 15.5 6.947627 15.5 10 C 15.5 13.052373 13.052375 15.5 10 15.5 C 6.9476251 15.5 4.5 13.052373 4.5 10 C 4.5 6.947627 6.9476251 4.5 10 4.5 z"
+    ></path>
+  </svg>
+</label>
+
+<dialog id="searchModal" class="modal">
+  <div class="modal-box">
+    <form method="dialog">
+      <button class="btn btn-ghost btn-xs absolute right-3 top-3">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          class="h-4 w-4"
+          fill="none"
+          viewBox="0 0 24 24"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M6 18L18 6M6 6l12 12"></path>
+        </svg>
+      </button>
+    </form>
+    <div id="search-box" class="mt-4"></div>
+  </div>
+  <form method="dialog" class="modal-backdrop">
+    <button>close</button>
+  </form>
+</dialog>
+
+<link rel="stylesheet" href="/pagefind/pagefind-ui.css" />
+<script is:inline src="/pagefind/pagefind-ui.js"></script>
+<script is:inline>
+  document.getElementById("search").addEventListener("click", () => {
+    document.getElementById("searchModal").showModal();
+  });
+  document.addEventListener("DOMContentLoaded", () => {
+    new PagefindUI({ element: "#search-box" });
+  });
+</script>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,24 +1,26 @@
+import { glob } from "astro/loaders";
 import { defineCollection, z } from "astro:content";
-import { glob } from 'astro/loaders';
 
 const blog = defineCollection({
-  loader: glob({ pattern: '**/[^_]*.{md,mdx}', base: "./src/content/blog" }),
+  loader: glob({ pattern: "**/[^_]*.{md,mdx}", base: "./src/content/blog" }),
   // Type-check frontmatter using a schema
-  schema: z.object({
-    title: z.string(),
-    description: z.string(),
-    tags: z.array(z.string()),
-    // Transform string to Date object
-    pubDate: z
-      .string()
-      .or(z.date())
-      .transform((val) => new Date(val)),
-    updatedDate: z
-      .string()
-      .optional()
-      .transform((str) => (str ? new Date(str) : undefined)),
-    heroImage: z.string().optional(),
-  }),
+  schema: ({ image }) =>
+    z.object({
+      title: z.string(),
+      description: z.string(),
+      tags: z.array(z.string()),
+      // Transform string to Date object
+      pubDate: z
+        .string()
+        .or(z.date())
+        .transform((val) => new Date(val)),
+      updatedDate: z
+        .string()
+        .optional()
+        .transform((str) => (str ? new Date(str) : undefined)),
+      eyeCatchImg: image().optional(),
+      eyeCatchAlt: z.string().optional(),
+    }),
 });
 
 export const collections = { blog };

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -5,22 +5,35 @@ const blog = defineCollection({
   loader: glob({ pattern: "**/[^_]*.{md,mdx}", base: "./src/content/blog" }),
   // Type-check frontmatter using a schema
   schema: ({ image }) =>
-    z.object({
-      title: z.string(),
-      description: z.string(),
-      tags: z.array(z.string()),
-      // Transform string to Date object
-      pubDate: z
-        .string()
-        .or(z.date())
-        .transform((val) => new Date(val)),
-      updatedDate: z
-        .string()
-        .optional()
-        .transform((str) => (str ? new Date(str) : undefined)),
-      eyeCatchImg: image().optional(),
-      eyeCatchAlt: z.string().optional(),
-    }),
+    z
+      .object({
+        title: z.string(),
+        description: z.string(),
+        tags: z.array(z.string()),
+        // Transform string to Date object
+        pubDate: z
+          .string()
+          .or(z.date())
+          .transform((val) => new Date(val)),
+        updatedDate: z
+          .string()
+          .optional()
+          .transform((str) => (str ? new Date(str) : undefined)),
+        eyeCatchImg: image().optional(),
+        eyeCatchAlt: z.string().optional(),
+      })
+      .refine(
+        (data) => {
+          if (data.eyeCatchImg && !data.eyeCatchAlt) {
+            return false;
+          }
+          return true;
+        },
+        {
+          message: "eyeCatchAlt is required when eyeCatchImg is set",
+          path: ["eyeCatchAlt"],
+        }
+      ),
 });
 
 export const collections = { blog };

--- a/src/content/blog/2023/build-keyball44-keyboard.md
+++ b/src/content/blog/2023/build-keyball44-keyboard.md
@@ -4,6 +4,7 @@ description: "Keyball44を組み立てた"
 tags: ["keyboard"]
 pubDate: "2023/10/05"
 eyeCatchImg: "src/assets/2023/build-keyball44-keyboard/20231005021215.jpg"
+eyeCatchAlt: "組み立てたkeyball44"
 ---
 
 ## Keyball44 を購入した理由

--- a/src/content/blog/2023/build-keyball44-keyboard.md
+++ b/src/content/blog/2023/build-keyball44-keyboard.md
@@ -3,9 +3,8 @@ title: "Keyball44を組み立てた"
 description: "Keyball44を組み立てた"
 tags: ["keyboard"]
 pubDate: "2023/10/05"
+eyeCatchImg: "src/assets/2023/build-keyball44-keyboard/20231005021215.jpg"
 ---
-
-![実際に組み立てたKeyball44](../../../assets/2023/build-keyball44-keyboard/20231005021215.jpg "実際に組み立てたKeyball44")
 
 ## Keyball44 を購入した理由
 

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,2 +1,0 @@
-/// <reference path="../.astro/types.d.ts" />
-/// <reference types="astro/client" />

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -6,6 +6,7 @@ import Navbar from "@components/Navbar";
 import Search from "@components/Search";
 import ThemeChange from "@components/ThemeChange";
 import TweetButton from "@components/TweetButton";
+import { Image } from "astro:assets";
 import type { CollectionEntry } from "astro:content";
 
 type Props = { blogData: CollectionEntry<"blog">["data"]; ogImage: string };
@@ -20,7 +21,7 @@ const url = new URL(Astro.url);
     <BaseHead
       title={blogData.title}
       description={blogData.description}
-      image={blogData.heroImage ?? ogImage}
+      image={blogData.eyeCatchImg?.src ?? ogImage}
     />
   </head>
   <body class="flex flex-col items-center h-screen">
@@ -31,15 +32,23 @@ const url = new URL(Astro.url);
       </Navbar>
       <div class="p-4 pt-6 pb-2">
         <div class="prose lg:prose-lg">
-          <article data-pagefind-body>
+          <article
+            data-pagefind-body
+            data-pagefind-meta={`image:${blogData.eyeCatchImg?.src ?? ogImage}`}
+          >
             {
-              blogData.heroImage && (
-                <img width={720} height={360} src={blogData.heroImage} alt="" />
+              blogData.eyeCatchImg && (
+                <Image
+                  width={720}
+                  height={360}
+                  src={blogData.eyeCatchImg}
+                  alt=""
+                />
               )
             }
+
             <h1 class="title">{blogData.title}</h1>
             <FormattedDate date={blogData.pubDate} />
-
             {
               blogData.updatedDate && (
                 <div class="last-updated-on">

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -31,7 +31,7 @@ const url = new URL(Astro.url);
       </Navbar>
       <div class="p-4 pt-6 pb-2">
         <div class="prose lg:prose-lg">
-          <article>
+          <article data-pagefind-body>
             {
               blogData.heroImage && (
                 <img width={720} height={360} src={blogData.heroImage} alt="" />

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -15,7 +15,7 @@ const url = new URL(Astro.url);
 ---
 
 <!doctype html>
-<html lang="en">
+<html lang="ja">
   <head>
     <BaseHead
       title={blogData.title}

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -13,7 +13,7 @@ const { blogData, ogImage } = Astro.props;
 const url = new URL(Astro.url);
 ---
 
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <BaseHead

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -3,6 +3,7 @@ import BaseHead from "@components/BaseHead";
 import Footer from "@components/Footer";
 import FormattedDate from "@components/FormattedDate";
 import Navbar from "@components/Navbar";
+import Search from "@components/Search";
 import ThemeChange from "@components/ThemeChange";
 import TweetButton from "@components/TweetButton";
 import type { CollectionEntry } from "astro:content";
@@ -25,6 +26,7 @@ const url = new URL(Astro.url);
   <body class="flex flex-col items-center h-screen">
     <div class="w-full max-w-3xl flex-grow">
       <Navbar>
+        <Search />
         <ThemeChange />
       </Navbar>
       <div class="p-4 pt-6 pb-2">

--- a/src/layouts/Page.astro
+++ b/src/layouts/Page.astro
@@ -10,7 +10,7 @@ const { description } = Astro.props;
 const { image } = Astro.props;
 ---
 
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <BaseHead

--- a/src/layouts/Page.astro
+++ b/src/layouts/Page.astro
@@ -2,6 +2,7 @@
 import BaseHead from "@components/BaseHead";
 import Footer from "@components/Footer";
 import Navbar from "@components/Navbar";
+import Search from "@components/Search";
 import ThemeChange from "@components/ThemeChange";
 import "../styles/global.css";
 
@@ -22,6 +23,7 @@ const { image } = Astro.props;
   <body class="flex flex-col items-center h-screen">
     <div class="w-full max-w-3xl flex-grow">
       <Navbar>
+        <Search />
         <ThemeChange />
       </Navbar>
       <div class="p-4 pt-10 pb-10">

--- a/src/layouts/Page.astro
+++ b/src/layouts/Page.astro
@@ -12,7 +12,7 @@ const { image } = Astro.props;
 ---
 
 <!doctype html>
-<html lang="en">
+<html lang="ja">
   <head>
     <BaseHead
     title={title}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -11,6 +11,8 @@
 
 /*
 モーダル表示時にガタつくのを防ぐworkaround
+デスクトップ表示で両サイドが白くなるけどしかたない
+DaisyUI V5でなおるっぽい
 https://github.com/saadeghi/daisyui/issues/3040#issuecomment-2250530354
 */
 :root:has(
@@ -21,7 +23,7 @@ https://github.com/saadeghi/daisyui/issues/3040#issuecomment-2250530354
         .modal[open]
       )
   ) {
-  scrollbar-gutter: unset;
+  scrollbar-gutter: stable both-edges;
 }
 
 .rlc-container {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -9,6 +9,21 @@
   }
 }
 
+/*
+モーダル表示時にガタつくのを防ぐworkaround
+https://github.com/saadeghi/daisyui/issues/3040#issuecomment-2250530354
+*/
+:root:has(
+    :is(
+        .modal-open,
+        .modal:target,
+        .modal-toggle:checked + .modal,
+        .modal[open]
+      )
+  ) {
+  scrollbar-gutter: unset;
+}
+
 .rlc-container {
   width: 100%;
   max-width: 800px;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,13 @@
 {
   "extends": "astro/tsconfigs/strict",
+  "include": [".astro/types.d.ts", "**/*"],
+  "exclude": ["dist"],
   "compilerOptions": {
     "strictNullChecks": true,
     "baseUrl": ".",
     "paths": {
-      "@components/*": [
-        "src/components/*.astro"
-      ],
-      "@layouts/*": [
-        "src/layouts/*.astro"
-      ]
+      "@components/*": ["src/components/*.astro"],
+      "@layouts/*": ["src/layouts/*.astro"]
     },
     "jsx": "react-jsx",
     "jsxImportSource": "react"


### PR DESCRIPTION
- **pagefindの導入とnpm run buildでindex作成**
- **モーダル表示時にスクロールバー部分がガタつくのを防ぐ**
- **pagefindのデフォUIをモーダルで表示する**
- **スクロールバーのがたつき調整**
- **ブログ記事だけをindexの対象とする**
- **findpageのスタイルを指定する**
- **日本語で検索されるようにする**
- **pagefind uiのcssを調整して色がいい感じになるようにする**
- **pagefindの検索UIにCSSをあてる**
- **一旦検索モーダルの閉じるボタンにフォーカス当たるの許容する**
- **pagefindの検索でアイキャッチ画像があればそっちを表示する**
- **zodでアイキャッチが設定されていたら代替テキストも必須とする**
