### PR TITLE
記事や職歴のmarkdown部分の最大幅を親のcontainerまで広がるようにする

### DIFF
--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -31,16 +31,17 @@ const url = new URL(Astro.url);
         <ThemeChange />
       </Navbar>
       <div class="p-4 pt-6 pb-2">
-        <div class="prose lg:prose-lg">
+        <div>
           <article
+            class="prose max-w-none"
             data-pagefind-body
             data-pagefind-meta={`image:${blogData.eyeCatchImg?.src ?? ogImage}`}
           >
             {
               blogData.eyeCatchImg && (
                 <Image
-                  width={720}
-                  height={360}
+                  width={768}
+                  height={300}
                   src={blogData.eyeCatchImg}
                   alt=""
                 />

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -5,7 +5,7 @@ import { Content as AboutCV } from "../content/about/AboutCV.md";
 
 <Page title="About Me" description="About futaooo profile detail">
   <h2 class="text-2xl font-bold">職務経歴</h2>
-  <div class="prose">
+  <div class="prose max-w-none">
     <AboutCV />
   </div>
 </Page>


### PR DESCRIPTION
ref
https://github.com/tailwindlabs/tailwindcss-typography?tab=readme-ov-file#overriding-max-width