### PR TITLE
fix: バグ修正・セキュリティ改善・SEO対応

### DIFF
--- a/app/components/BaseHead.tsx
+++ b/app/components/BaseHead.tsx
@@ -28,6 +28,7 @@ export const BaseHead = ({
         title='RSS Feed'
         href='/rss.xml'
       />
+      <link rel='sitemap' type='application/xml' href='/sitemap.xml' />
       <meta name='generator' content='Hono' />
 
       {/* Canonical URL */}

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -1,8 +1,9 @@
+import type { Child } from 'hono/jsx'
 import { IC_FUTABOOO, SITE_TITLE } from '../consts'
 
 interface Props {
   pathName?: string
-  children?: any
+  children?: Child
 }
 
 const navItem = [

--- a/app/lib/blog.ts
+++ b/app/lib/blog.ts
@@ -1,8 +1,8 @@
-import { default as matter } from 'gray-matter';
-import hljs from 'highlight.js';
-import { Marked } from 'marked';
-import { markedHighlight } from "marked-highlight";
-import { z } from 'zod';
+import { default as matter } from 'gray-matter'
+import hljs from 'highlight.js'
+import { Marked } from 'marked'
+import { markedHighlight } from 'marked-highlight'
+import { z } from 'zod'
 
 export interface BlogPost {
   id: string
@@ -46,6 +46,17 @@ const blogPostMetaDataSchema = z
     }
   )
 
+const marked = new Marked(
+  markedHighlight({
+    emptyLangClass: 'hljs',
+    langPrefix: 'hljs language-',
+    highlight(code, lang) {
+      const language = hljs.getLanguage(lang) ? lang : 'plaintext'
+      return hljs.highlight(code, { language }).value
+    },
+  })
+)
+
 // viteのbuild時にすべてのindex.mdファイルを読み込む
 const markdownFiles = import.meta.glob('../../content/blog/**/index.md', {
   eager: true,
@@ -61,17 +72,7 @@ export const allPosts: BlogPost[] = Object.entries(markdownFiles)
     const slug = pathParts[pathParts.length - 2] || ''
     const { data, content } = matter(raw as string)
     const validatedMetaData = blogPostMetaDataSchema.parse(data)
-    const marked = new Marked(
-      markedHighlight({
-      emptyLangClass: 'hljs',
-        langPrefix: 'hljs language-',
-        highlight(code, lang, info) {
-          const language = hljs.getLanguage(lang) ? lang : 'plaintext';
-          return hljs.highlight(code, { language }).value;
-        }
-      })
-    );
-    const html = marked.parse(content,{async: false})
+    const html = marked.parse(content, { async: false })
 
     return {
       id: slug,
@@ -87,7 +88,7 @@ export function getPostById(id: string) {
   return allPosts.find((post) => post.id === id) || null
 }
 
-export async function getPostsByTag(tag: string) {
+export function getPostsByTag(tag: string) {
   return allPosts.filter((post) => post.data.tags.includes(tag))
 }
 

--- a/app/routes/_renderer.tsx
+++ b/app/routes/_renderer.tsx
@@ -7,7 +7,8 @@ import { jsxRenderer } from 'hono/jsx-renderer'
 import { Link, Script } from 'honox/server'
 
 export default jsxRenderer(
-  ({ children, title, description, image, canonicalURL }) => {
+  ({ children, title, description, image, canonicalURL }, c) => {
+    const pathName = new URL(c.req.url).pathname
     return (
       <html lang='ja'>
         <head>
@@ -24,7 +25,7 @@ export default jsxRenderer(
         </head>
         <body class='flex flex-col items-center h-screen'>
           <div class='w-full max-w-3xl flex-grow px-6'>
-            <Navbar pathName='/'>
+            <Navbar pathName={pathName}>
               <Search />
               <ThemeChange />
             </Navbar>

--- a/app/routes/blog/[slug]/assets/[filename].tsx
+++ b/app/routes/blog/[slug]/assets/[filename].tsx
@@ -1,22 +1,29 @@
 import { createRoute } from 'honox/factory'
 import { readFileSync, existsSync } from 'node:fs'
-import { join } from 'node:path'
+import { resolve } from 'node:path'
 
 export default createRoute(async (c) => {
   const slug = c.req.param('slug')
   const filename = c.req.param('filename')
-  
+
+  // パストラバーサル対策: 許可ディレクトリ内かを確認
+  const allowedDir = resolve(process.cwd(), 'content', 'blog')
+  const imagePath = resolve(allowedDir, slug, 'assets', filename)
+
+  if (!imagePath.startsWith(allowedDir + '/')) {
+    c.status(403)
+    return c.text('Forbidden')
+  }
+
   // 開発環境でのみ動作する静的ファイル配信
-  const imagePath = join(process.cwd(), 'content', 'blog', slug, 'assets', filename)
-  
   if (!existsSync(imagePath)) {
     c.status(404)
     return c.text('Not Found')
   }
-  
+
   const imageBuffer = readFileSync(imagePath)
   const ext = filename.split('.').pop()?.toLowerCase()
-  
+
   // Content-Typeを設定
   const contentTypeMap: Record<string, string> = {
     png: 'image/png',
@@ -26,10 +33,9 @@ export default createRoute(async (c) => {
     svg: 'image/svg+xml',
     webp: 'image/webp',
   }
-  
+
   const contentType = contentTypeMap[ext || ''] || 'application/octet-stream'
-  
+
   c.header('Content-Type', contentType)
   return c.body(imageBuffer)
 })
-

--- a/app/routes/sitemap.xml.tsx
+++ b/app/routes/sitemap.xml.tsx
@@ -1,0 +1,35 @@
+import { createRoute } from 'honox/factory'
+import { SITE_URL } from '../consts'
+import { allPosts } from '../lib/blog'
+
+export default createRoute((c) => {
+  const staticPages = ['/', '/blog', '/about']
+  const postUrls = allPosts.map((post) => ({
+    url: `${SITE_URL}/blog/${post.id}`,
+    lastmod: (post.data.updatedDate ?? post.data.pubDate)
+      .toISOString()
+      .split('T')[0],
+  }))
+
+  const urls = [
+    ...staticPages.map((path) => ({
+      url: `${SITE_URL}${path}`,
+      lastmod: undefined as string | undefined,
+    })),
+    ...postUrls,
+  ]
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urls
+  .map(
+    ({ url, lastmod }) =>
+      `  <url>\n    <loc>${url}</loc>${lastmod ? `\n    <lastmod>${lastmod}</lastmod>` : ''}\n  </url>`
+  )
+  .join('\n')}
+</urlset>`
+
+  return c.body(xml, 200, {
+    'Content-Type': 'application/xml; charset=utf-8',
+  })
+})


### PR DESCRIPTION
- Navbar: `children` の型を `any` から `Child` (hono/jsx) に修正
- _renderer: 実際のパス名を動的に取得してNavbarに渡す
- assets route: パストラバーサル対策を追加 (resolve + startsWith検証)
- blog.ts: Markedインスタンスをmap()ループ外に移動して最適化、getPostsByTagのasyncを削除
- sitemap.xml.tsx: サイトマップエンドポイントを新規作成
- BaseHead: sitemapリンクタグを追加

https://claude.ai/code/session_015KBBnXE4jUHx2a8wPJ4d4s