### PR TITLE
fix: 拍手APIへのPOSTが本番で405になる問題を修正

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -7,7 +7,10 @@
     "nodejs_compat"
   ],
   "assets": {
-    "directory": "./dist"
+    "directory": "./dist",
+    // /api/* は静的アセット層(GET/HEADのみ)ではなくWorkerを先に通す。
+    // これが無いと本番で /api/* へのPOSTがアセット層に弾かれ405になる。
+    "run_worker_first": ["/api/*"]
   },
   // 記事ごとのいいね(拍手)数を保存するKV。
   // id=本番(wrangler deploy), preview_id=ローカル/プレビュー(wrangler dev)


### PR DESCRIPTION
## 問題

本番(`https://futabooo.com`)で拍手ボタンを押すと、`POST /api/likes/:slug` が **405 Method Not Allowed** になる。Cloudflare のアセット層が返すレスポンス(`Server: cloudflare` / `Cf-Cache-Status: DYNAMIC` / `Access-Control-Allow-Origin: *`)で、Hono のハンドラには届いていなかった。GET(カウント取得)は通るため、表示だけは動いていた。

## 原因

Cloudflare Workers + 静的アセット構成では、既定で**アセット層が先に評価**される。アセット層は GET/HEAD のみ対応のため、`/api/*` への POST はマッチするアセットが無くても Worker へフォールスルーされず **405** になる。

`bun run dev`(Vite) も `wrangler dev`(ローカル miniflare) もこのエッジ挙動を再現せず POST が 200 になるため、実装時に見逃していた。

## 修正

`wrangler.jsonc` の `assets` に `run_worker_first: ["/api/*"]` を追加。`/api/*` はアセット層をバイパスして Worker を先に通す。静的ページ・アセットは従来どおりアセット層が処理する。

```jsonc
"assets": {
  "directory": "./dist",
  "run_worker_first": ["/api/*"]
}
```

## 検証

`wrangler dev` でのローカル回帰(エッジの405はローカルでは再現しないため、あくまで非回帰確認):
- `POST /api/likes/:slug` → 200 ✅
- `GET /api/likes/:slug` → 200 ✅
- `GET /`、`GET /blog/:slug` → 200 / `text/html`(静的配信 無傷) ✅

⚠️ **本番での最終確認はマージ後の `bun run deploy` が必要**です(ローカルでは405を再現できないため)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)