### PR TITLE
fix: package.jsonのtrailing commaを削除してCloudflareビルド失敗を修正

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -46,5 +46,15 @@
     "parser": {
       "tailwindDirectives": true
     }
-  }
+  },
+  "overrides": [
+    {
+      "includes": ["package.json"],
+      "json": {
+        "formatter": {
+          "trailingCommas": "none"
+        }
+      }
+    }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "dev": "vite",
     "build": "vite build --mode client && vite build && pagefind --site dist",
     "preview": "wrangler dev",
-    "deploy": "bun run build && wrangler deploy",
+    "deploy": "bun run build && wrangler deploy"
   },
   "private": true,
   "dependencies": {
@@ -20,7 +20,7 @@
     "pagefind": "^1.4.0",
     "satori": "^0.19.0",
     "sharp": "^0.34.5",
-    "zod": "^4.2.1",
+    "zod": "^4.2.1"
   },
   "devDependencies": {
     "@biomejs/biome": "2.3.15",
@@ -33,6 +33,6 @@
     "daisyui": "^5.5.14",
     "tailwindcss": "^4.1.18",
     "vite": "^7.3.0",
-    "wrangler": "^4.54.0",
-  },
+    "wrangler": "^4.54.0"
+  }
 }


### PR DESCRIPTION
## Summary
- `package.json` に混入していたtrailing commaを削除（strictなJSONに戻す）
- `biome.json` に `package.json` 専用のoverrideを追加し、`json.formatter.trailingCommas` を `none` に固定して再発を防止

## 原因
`f2e9fd8` の `biome check --write` 実行時、`biome.json` の `json.formatter.trailingCommas: "all"` により `package.json` にtrailing commaが自動挿入された。Cloudflare PagesのビルドはesbuildでJSONを厳密にパースするため `JSON does not support trailing commas` で失敗し、`"type": "module"` の読み取り失敗により `honox/vite` 等のESM importが `require` 扱いされるエラーも連鎖していた。

## Test plan
- [x] `python3 -c "import json; json.load(open('package.json'))"` でstrict JSONとして検証
- [x] `bunx biome check package.json` がtrailing commaを追加しないことを確認
- [x] `bun run build` がローカルで成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)