### PR TITLE
fix: クライアントスクリプトのasyncを削除してislandハイドレーションのレースを修正

### DIFF
--- a/app/routes/_renderer.tsx
+++ b/app/routes/_renderer.tsx
@@ -19,7 +19,10 @@ export default jsxRenderer(
             canonicalURL={canonicalURL}
           />
           <Link href='/app/style.css' rel='stylesheet' />
-          <Script src='/app/client.ts' async />
+          {/* asyncを付けるとHTML解析完了前にcreateClient()が実行され、
+              ページ下部のislandを取りこぼすレースが起きるので付けない
+              (type=moduleはデフォルトでdefer相当なので実行は解析完了後になる) */}
+          <Script src='/app/client.ts' />
           <link href='/pagefind/pagefind-ui.css' rel='stylesheet' />
           <script src='/pagefind/pagefind-ui.js' async />
         </head>


### PR DESCRIPTION
## 問題

ブログ記事の初回アクセス時、いいね(拍手)ボタンのカウントが `–` のまま固まることがある(リロードすると直る)。

## 原因

`_renderer.tsx` で `<Script src='/app/client.ts' async />` と `async` を付けていたため、HTML解析完了前にスクリプトが実行されることがある。HonoXの `createClient()` は実行時に1回だけ `querySelectorAll` で島を探す方式(DOMContentLoaded待ちなし・再スキャンなし)なので、ページ下部の島がまだDOMに存在しないタイミングで実行されるとハイドレーションが永久にスキップされる。

- 初回(コールドキャッシュ)は長い記事HTMLのストリーミング中にスクリプトのダウンロードが完了しやすく、レースに負けやすい
- リロード時はキャッシュでタイミングが変わり成功する → 「初回だけハイフン」という症状に一致

本番環境で再現確認済み: 失敗時は `client-*.js` 読み込み後にFavoriteButtonチャンクのリクエストも `/api/likes` fetchも発生せず、コンソールエラーもなし。

## 修正

`async` を削除。`type="module"` スクリプトはデフォルトでdefer相当(ダウンロードは並行、実行はHTML解析完了後)のため、ダウンロードの並行性は維持したまま実行順だけが保証され、レースが構造的に解消する。

## 確認

- `bun run build` 成功、出力HTMLの `<script>` から `async` が消えていることを確認
- `bun run preview` + キャッシュなし隔離ブラウザの初回アクセスで、島がハイドレーションされカウントが表示されることを確認
- `bunx biome check app/routes/_renderer.tsx` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)