### PR TITLE
fix: VSCode保存時にbiomeのimport整理が効かない問題を修正

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,28 @@
 {
   "editor.defaultFormatter": "biomejs.biome",
   "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.organizeImports": "never",
+    "source.organizeImports.biome": "explicit"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[javascriptreact]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
   "editor.quickSuggestions": {
     "strings": true
   },

--- a/app/lib/ogimage.tsx
+++ b/app/lib/ogimage.tsx
@@ -1,5 +1,5 @@
-import { loadDefaultJapaneseParser } from 'budoux'
 import fs from 'node:fs'
+import { loadDefaultJapaneseParser } from 'budoux'
 import satori from 'satori'
 import sharp from 'sharp'
 

--- a/app/routes/blog/[slug]/assets/[filename].tsx
+++ b/app/routes/blog/[slug]/assets/[filename].tsx
@@ -1,6 +1,6 @@
-import { createRoute } from 'honox/factory'
-import { readFileSync, existsSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
+import { createRoute } from 'honox/factory'
 
 export default createRoute(async (c) => {
   const slug = c.req.param('slug')

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,3 @@
-import build from '@hono/vite-build/cloudflare-workers'
-import adapter from '@hono/vite-dev-server/cloudflare'
-import ssg from '@hono/vite-ssg'
-import tailwindcss from '@tailwindcss/vite'
-import { default as matter } from 'gray-matter'
-import honox from 'honox/vite'
 import {
   copyFileSync,
   existsSync,
@@ -14,6 +8,12 @@ import {
 } from 'node:fs'
 import type { IncomingMessage, ServerResponse } from 'node:http'
 import { dirname, join, resolve } from 'node:path'
+import build from '@hono/vite-build/cloudflare-workers'
+import adapter from '@hono/vite-dev-server/cloudflare'
+import ssg from '@hono/vite-ssg'
+import tailwindcss from '@tailwindcss/vite'
+import { default as matter } from 'gray-matter'
+import honox from 'honox/vite'
 import type { ViteDevServer } from 'vite'
 import { defineConfig } from 'vite'
 import { generateOGImage } from './app/lib/ogimage'


### PR DESCRIPTION
## Summary
- グローバル(ユーザー)のVSCode設定で `[typescript]` の `editor.defaultFormatter` がPrettierになっており、かつ `editor.codeActionsOnSave` の `source.organizeImports` がTypeScript組み込みのimport整理アクションを指していたため、ワークスペース側の biome 設定より優先されてしまい、保存時にbiomeのimportソートが適用されていなかった
- `.vscode/settings.json` に言語指定(`[typescript]`等)の `defaultFormatter: biomejs.biome` と、`source.organizeImports.biome` を使う `codeActionsOnSave` を追加してユーザー設定を上書き
- `bunx biome check app --write` を実行し、既存ファイル(vite.config.ts, app/lib/ogimage.tsx, app/routes/blog/[slug]/assets/[filename].tsx)のimport順序をbiomeのルールに揃えた

## Test plan
- [x] `bunx biome check app` で警告が出ないことを確認
- [ ] VSCodeでファイルを開き直し、cmd+sでimportがbiomeの順序通りにソートされたまま保持されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)